### PR TITLE
New versions, MCE gathering improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # acm_create-must-gather.sh - must-gather automation
     
 Script to automate process of creating must-gather for RHACM support,
-initial version.
 
 This script checks ACM and MCE version and create proper must-gathers
-for support team. This script is aimed to run on HUB cluster now.
+for support team. This script is aimed to run on HUB or managed cluster now.
 
 Works with ACM version 2.4, 2.5, 2.6 and 2.7, prepared for ACM 2.8
+
+## Disclaimer:
+
+This scripts are NOT delivered and/or released by Red Hat. This is an independent project to help customers and Red Hat Support team to export and/or collect the data from Red Hat Advanced Cluster Management and managed clusters for reporting or troubleshooting purposes.
 
 ## Usage:
 
@@ -34,13 +37,22 @@ OUTPUT_DIR/
 
 `OUTPUT_DIR` is archived to `./acm_must_gather-$TIMESTAMP.tar.xz`
 
+## Requirements:
+
+The script is written in BASH and for successful usage needs:
+  * **oc** - CLI tool for manage OpenShift clusters - https://console.redhat.com/openshift/downloads
+  * **jq** - Tool for parsing JSON. Part of linux distributions, how to install, please check your distribution manual
+  * **tar** and few other common linux CLI tools.
+
+The script is tested on Linux distributions.
+
 ## Known issues:
-  * Not tested on non-HUB cluster for now.
+  * ~~Not tested on non-HUB cluster for now.~~ - For collecting data from managed cluster, use `-m <ACM version>` option
   * Do not cover situation, when image for m-g is not available, but
     this can be checked from `oc adm must-gather ...` output in specified
     dir (acm-must-gather.log and mce-must-gather.log).
 
+
 ## TODO:
   * when executed on HUB cluster, show message like "This script gather data from HUB cluster now. If your issue with ACM affects some managed cluster, please run this script to gather data from managed cluster too." - done
   * Add functionality to collect data for submariner support
-

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Script to automate process of creating must-gather for RHACM support,
 This script checks ACM and MCE version and create proper must-gathers
 for support team. This script is aimed to run on HUB or managed cluster now.
 
-Works with ACM version 2.4, 2.5, 2.6 and 2.7, prepared for ACM 2.8
+Works with ACM version 2.4, 2.5, 2.6, 2.7 and 2.8
 
 ## Disclaimer:
 
@@ -54,9 +54,10 @@ The script is tested on Linux distributions.
 
 ## Known issues:
   * ~~Not tested on non-HUB cluster for now.~~ - For collecting data from managed cluster, use `-m <ACM version>` option
-  * Do not cover situation, when image for m-g is not available, but
+  * ~~Do not cover situation, when image for m-g is not available,~~ but
     this can be checked from `oc adm must-gather ...` output in specified
     dir (acm-must-gather.log and mce-must-gather.log).
+    * It is possible to specify own image registry via `-r` parameter
 
 
 ## TODO:

--- a/README.md
+++ b/README.md
@@ -61,4 +61,4 @@ The script is tested on Linux distributions.
 
 ## TODO:
   * when executed on HUB cluster, show message like "This script gather data from HUB cluster now. If your issue with ACM affects some managed cluster, please run this script to gather data from managed cluster too." - done
-  * Add functionality to collect data for submariner support
+  * ~~Add functionality to collect data for submariner support~~ - use `-s` parameter to collect submariner data

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Common usage is:
 $ acm_create-must-gather.sh -d OUTPUT_DIR
 ```
 
+or with specified own registry (for disconnected env):
+
+```
+$ acm_create-must-gather.sh -d OUTPUT_DIR -r internal.repo.address:port
+```
+
 The `OUTPUT_DIR` must not exists. This dir is created. Output structure:
 
 ```

--- a/acm_create-must-gather.sh
+++ b/acm_create-must-gather.sh
@@ -114,13 +114,13 @@ isupdate() {
 					fi
 				;;
 				*)
-					echo "UNNOWN VERSION: $1"
+					echo "UNKNOWN VERSION: $1"
 				;;
 			esac
 			
 		;;
 		*)
-			echo "UNNOWN VERSION: $1"
+			echo "UNKNOWN VERSION: $1"
 		;;
 	esac
 

--- a/acm_create-must-gather.sh
+++ b/acm_create-must-gather.sh
@@ -19,10 +19,25 @@ MCEFIX25=7
 MCEFIX26=5
 MCEFIX27=3
 
+GENERATION=1683279072
+RETIRED=7689599
+VERSION="1.0"
+SOURCE="https://github.com/C-RH-C/ACM-MCE-must-gather/blob/main/acm_create-must-gather.sh"
+
+isretired() {
+	AGE=`date +%s`
+	AGE=$(($AGE - $GENERATION))
+	if [ $AGE -gt $RETIRED ]; then
+		echo "This script is older then 3 months, please check for latest version"
+		echo "The latest version should be available here: $SOURCE"
+	fi
+}
+
 help() {
 	echo -e "Usage: $0 [OPTION]"
 	echo -e "\n\tThis is helper script for collecting"
-	echo -e "\tall must-gathers neccesary for support"
+	echo -e "\tall must-gathers neccesary for support."
+	echo -e "\tSource repository of this script: $SOURCE"
 	echo -e "Options:"
 	echo -e "\t${_bold_}-h${_norm_}\t\tShow this help"
 	echo -e "\t${_bold_}-d <dest>${_norm_}\tSave all gatherred data to this directory."
@@ -32,9 +47,9 @@ help() {
 	echo -e "\t\t\tdo not collect any data"
 	echo -e "\nPrerequisities:"
 	echo -e "\t${_bold_}oc${_norm_} - download actual version from https://console.redhat.com/openshift/downloads."
-	echo -e "\t${_bold_}jq${_norm_} - CLI JSON processor - part of common Linux distributions, for installation check your distro documentation"
+	echo -e "\t${_bold_}jq${_norm_} - CLI JSON processor - part of common Linux distributions, for installation check your distro documentation\n"
+	isretired
 }
-
 
 isupdate() {
 
@@ -198,6 +213,7 @@ then
 	echo "Prerequisities ${_bold_}OK${_norm_}"
 	echo
 
+	isretired
 fi
 
 if ! oc whoami &> /dev/null;
@@ -236,6 +252,7 @@ MCE_IMAGE=`mcemgimage $ACM_VERSION`
 MCE_VERSION=`oc get subs -n multicluster-engine multicluster-engine -o json 2>/dev/null | jq '.status.currentCSV' | sed -e 's/.*\.v//; s/"//'`
 
 echo -e "${_bold_}Detected versions:${_norm_}
+  ${_bold_}* This script:${_norm_} ${VERSION}-${GENERATION}
   ${_bold_}* Cluster:${_norm_}\t$CLUSTER_VERSION
   ${_bold_}* ACM:${_norm_}\t$ACM_VERSION
   ${_bold_}* MCE:${_norm_}\t$MCE_VERSION"
@@ -301,6 +318,9 @@ fi
 
 TIMESTAMP=`date +%s`
 
+echo "Used version: ${VERSION}-${GENERATION}" > "${DIR}/VERSION.txt"
+echo "Command: \"$0 $@\"" >> "${DIR}/VERSION.txt"
+
 echo -n "Creating archive with collected data... "
 
 RETVAL=255
@@ -347,4 +367,3 @@ then
 	echo -e "\tuse following command to gather data from managed cluster:${_norm_}"
 	echo -e "\t# $0 -m $ACM_VERSION -d <dest>"
 fi
-

--- a/acm_create-must-gather.sh
+++ b/acm_create-must-gather.sh
@@ -19,9 +19,9 @@ MCEFIX25=7
 MCEFIX26=5
 MCEFIX27=3
 
-GENERATION=1685703227
+GENERATION=1686916233
 RETIRED=7689599
-VERSION="1.0"
+VERSION="1.1"
 SOURCE="https://github.com/C-RH-C/ACM-MCE-must-gather/blob/main/acm_create-must-gather.sh"
 
 isretired() {
@@ -42,6 +42,8 @@ help() {
 	echo -e "\t${_bold_}-h${_norm_}\t\tShow this help"
 	echo -e "\t${_bold_}-d <dest>${_norm_}\tSave all gatherred data to this directory."
 	echo -e "\t\t\tDestination directory must be empty!"
+	echo -e "\t${_bold_}-r <registry>${_norm_}\tSpecify own registry in case of registry.redhat.io is not available."
+	echo -e "\t\t\tUse format \"internal.repo.address:port\""
 	echo -e "\t${_bold_}-m <version>${_norm_}\tEnforce ACM version for gather data from managed cluster"
 	echo -e "\t${_bold_}-t${_norm_}\t\tTest run - test all requirements and show executed commands,"
 	echo -e "\t\t\tdo not collect any data"
@@ -139,19 +141,19 @@ mcemgimage() {
 				4) echo '-'
 				;;
 				5) if [ "${ver[2]}" -lt "$MCEFIX25" ]; then
-					echo "registry.redhat.io/multicluster-engine/must-gather-rhel8:v2.0.0"
+					echo "${REGISTRY}/multicluster-engine/must-gather-rhel8:v2.0"
 				   else
 					echo '-'
 				   fi
 				;;
 				6) if [ "${ver[2]}" -lt "$MCEFIX26" ]; then
-					echo "registry.redhat.io/multicluster-engine/must-gather-rhel8:v2.1.0"
+					echo "${REGISTRY}/multicluster-engine/must-gather-rhel8:v2.1"
 				   else
 					echo '-'
 				   fi
 				;;
 				7) if [ "${ver[2]}" -lt "$MCEFIX27" ]; then
-					echo "registry.redhat.io/multicluster-engine/must-gather-rhel8:v2.2.0"
+					echo "${REGISTRY}/multicluster-engine/must-gather-rhel8:v2.2"
 				   else
 					echo '-'
 				   fi
@@ -171,8 +173,9 @@ mcemgimage() {
 ACM_VERSION='-'
 ACM_CHANNEL='-'
 MANAGED='-'
+REGISTRY='registry.redhat.io'
 
-while getopts td:m:h flag
+while getopts tsd:m:r:h flag
 do
     case "${flag}" in
         t) DRY_RUN=yes;;
@@ -182,6 +185,7 @@ do
 	   ACM_CHANNEL="release-${OPTARG::3}"
 	   MANAGED='yes'
 	;;
+	r) REGISTRY=${OPTSRG};;
     esac
 done
 
@@ -244,7 +248,7 @@ MCE_VERSION="-"
 
 case $ACM_CHANNEL in
 	release-2.4|release-2.5|release-2.6|release-2.7|release-2.8)
-		ACM_IMAGE="registry.redhat.io/rhacm2/acm-must-gather-rhel8:v${ACM_CHANNEL#release-}.0"
+		ACM_IMAGE="${REGISTRY}/rhacm2/acm-must-gather-rhel8:v${ACM_CHANNEL#release-}"
 	;;
 esac
 

--- a/acm_create-must-gather.sh
+++ b/acm_create-must-gather.sh
@@ -10,18 +10,14 @@ _red_="${Esc}[0;31m" #set red
 _boldred_="${Esc}[0;1;31m" #set bold and red.
 
 REL24=99
-REL25=9
+REL25=99
 REL26=6
-REL27=4
-REL28=0
+REL27=7
+REL28=1
 
-MCEFIX25=7
-MCEFIX26=5
-MCEFIX27=3
-
-GENERATION=1687176791
+GENERATION=1693472605
 RETIRED=7689599
-VERSION="1.3"
+VERSION="1.4"
 SOURCE="https://github.com/C-RH-C/ACM-MCE-must-gather/blob/main/acm_create-must-gather.sh"
 
 isretired() {
@@ -72,18 +68,11 @@ isupdate() {
 					UPDOC="Upgrade to 2.5 version: https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.5/html/install/index"
 				;;
 				5)
-					echo "THIS VERSION WILL BE EOL SOON, PLEASE UPGRADE TO 2.6"
-					if [ "${ver[2]}" -lt "$REL25" ]; then
-						echo "Upgrade available to 2.5.$REL25 or 2.6"
-					else
-						echo "Upgrade available to 2.6"
-					fi
-					if [ "${ver[2]}" -lt "7" ]; then
-						AFFECTED_CVE_2023_29017="yes"
-					fi
+					echo "THIS VERSION IS NO LONGER SUPPORTED, PLEASE UPGRADE TO 2.6"
 					UPDOC="Upgrade to 2.6 version: https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.6/html/install/index"
 				;;
 				6)
+					echo "THIS VERSION WIL BE EOL SOON, PLEASE UPGRADE TO 2.7"
 					if [ "${ver[2]}" -lt "$REL26" ]; then
 						echo "Upgrade available to 2.6.$REL26 or 2.7"
 					else 
@@ -143,39 +132,36 @@ mcemgimage() {
 
 	ENFORCE="$2"
 
-	#echo ">>>$1>>>${ver[0]}>${ver[1]}>${ver[2]}>" >&2
 	case ${ver[0]} in
 		2)
+			VERSION='-'
 			case ${ver[1]} in
-				4) echo '-'
+				4) VERSION='-'
 				;;
-				5) if [ "${ver[2]}" -lt "$MCEFIX25" -o "x${ENFORCE}" == "xyes" ]; then
-					echo "${REGISTRY}/multicluster-engine/must-gather-rhel8:v2.0"
-				   else
-					echo '-'
+				5) VERSION="2.0"
+				;;
+				6) if [ "x${ENFORCE}" == "xyes" ]; then
+					VERSION="2.1"
 				   fi
 				;;
-				6) if [ "${ver[2]}" -lt "$MCEFIX26" -o "x${ENFORCE}" == "xyes" ]; then
-					echo "${REGISTRY}/multicluster-engine/must-gather-rhel8:v2.1"
-				   else
-					echo '-'
-				   fi
-				;;
-				7) if [ "${ver[2]}" -lt "$MCEFIX27" -o "x${ENFORCE}" == "xyes" ]; then
-					echo "${REGISTRY}/multicluster-engine/must-gather-rhel8:v2.2"
-				   else
-					echo '-'
+				7) if [ "x${ENFORCE}" == "xyes" ]; then
+					VERSION="2.2"
 				   fi
 				;;
 				8) if [ "x${ENFORCE}" == "xyes" ]; then
-					echo "${REGISTRY}/multicluster-engine/must-gather-rhel8:v2.3"
-				   else
-					echo '-'
+					VERSION="2.3"
 				   fi
 				;;
-				*) echo '-'
+				*) VERSION='-'
 				;;
 			esac
+
+			if [ "x${VERSION}" == "x-" ]; then
+				echo '-'
+			else
+				echo "${REGISTRY}/multicluster-engine/must-gather-rhel8:v${VERSION}"
+			fi
+	
 		;;
 		*)
 			echo "-"

--- a/acm_create-must-gather.sh
+++ b/acm_create-must-gather.sh
@@ -19,9 +19,9 @@ MCEFIX25=7
 MCEFIX26=5
 MCEFIX27=3
 
-GENERATION=1686916233
+GENERATION=1687176791
 RETIRED=7689599
-VERSION="1.1"
+VERSION="1.2"
 SOURCE="https://github.com/C-RH-C/ACM-MCE-must-gather/blob/main/acm_create-must-gather.sh"
 
 isretired() {
@@ -72,6 +72,7 @@ isupdate() {
 					UPDOC="Upgrade to 2.5 version: https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.5/html/install/index"
 				;;
 				5)
+					echo "THIS VERSION WILL BE EOL SOON, PLEASE UPGRADE TO 2.6"
 					if [ "${ver[2]}" -lt "$REL25" ]; then
 						echo "Upgrade available to 2.5.$REL25 or 2.6"
 					else
@@ -97,11 +98,13 @@ isupdate() {
 					if [ "${ver[2]}" -lt "$REL27" ]; then
 						echo "Upgrade available to 2.7.$REL27"
 						UPDOC=""
+					else
+						echo "Upgrade available to 2.8"	
 					fi
 					if [ "${ver[2]}" -lt "3" ]; then
 						AFFECTED_CVE_2023_29017="yes"
 					fi
-					UPDOC="Upgrade to latest 2.7 version: https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/install/index"
+					UPDOC="Upgrade to 2.8 version: https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/install/index"
 
 				;;
 				8)

--- a/acm_create-must-gather.sh
+++ b/acm_create-must-gather.sh
@@ -10,16 +10,16 @@ _red_="${Esc}[0;31m" #set red
 _boldred_="${Esc}[0;1;31m" #set bold and red.
 
 REL24=99
-REL25=7
-REL26=4
-REL27=3
+REL25=9
+REL26=6
+REL27=4
 REL28=0
 
 MCEFIX25=7
 MCEFIX26=5
 MCEFIX27=3
 
-GENERATION=1683279072
+GENERATION=1685703227
 RETIRED=7689599
 VERSION="1.0"
 SOURCE="https://github.com/C-RH-C/ACM-MCE-must-gather/blob/main/acm_create-must-gather.sh"


### PR DESCRIPTION
Support for latest ACM versions, deprecated ACM 2.5 and warning for EOL of 2.6.

Optimized gathering MCE - If you have image 2.6/2.7/2.8, MCE is automaticaly gathered with ACM data. You can enforce gathering MCE in separate folder with -M  option (this option is not published yet).

Some code clean-ups.